### PR TITLE
Add homepage explaining the CleanTime.live tool

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,8 +22,13 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser('diffcalc-secret-key'));
 app.use(express.static(path.join(__dirname, 'public')));
 
-// Health check endpoint for Render
+// Homepage
 app.get('/', function(req, res) {
+  res.render('home');
+});
+
+// Health check endpoint for Render
+app.get('/health', function(req, res) {
   res.status(200).send('OK');
 });
 

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: diffcalc
     runtime: docker
     plan: free
-    healthCheckPath: /
+    healthCheckPath: /health
     envVars:
       - key: NODE_ENV
         value: production

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -12,16 +12,16 @@
 
         <div class="message">
             <p><strong>What is CleanTime.live?</strong></p>
-            <p>CleanTime.live is a tool for recovery groups to collectively track and celebrate sobriety milestones. It allows groups to gather clean time data from their members and display combined totals during celebrations, anniversaries, and events.</p>
+            <p>CleanTime.live is a tool for recovery events or groups to collectively track and celebrate clean time milestones. It allows events or groups to gather clean time data from their members and display combined totals during celebrations, anniversaries, and special occasions.</p>
         </div>
 
         <div class="admin-section">
             <h2 style="color: #667eea; margin-bottom: 15px;">How It Works</h2>
             <ul style="list-style-position: inside; line-height: 2;">
-                <li>Each group gets their own private space</li>
+                <li>Each event or group gets their own private space</li>
                 <li>Members submit their clean date via a simple form</li>
-                <li>The tool calculates years, months, and days of sobriety</li>
-                <li>Groups can view combined totals for celebrations</li>
+                <li>The tool calculates years, months, and days of clean time</li>
+                <li>Events or groups can view combined totals for celebrations</li>
                 <li>QR codes available for easy mobile access</li>
             </ul>
         </div>
@@ -30,7 +30,7 @@
 
         <div class="admin-section">
             <h2 style="color: #667eea; margin-bottom: 15px;">Request Access</h2>
-            <p style="margin-bottom: 15px;">CleanTime.live is not self-service. To request a space for your group, please submit an issue on GitHub:</p>
+            <p style="margin-bottom: 15px;">CleanTime.live is not self-service. To request a space for your event or group, please submit an issue on GitHub:</p>
             <a href="https://github.com/bmlt-enabled/diffcalc/issues/new?title=Request%20new%20group%20space&body=Group%20name:%0AContact%20email:%0A"
                class="btn-edit"
                style="display: inline-block; padding: 14px 30px; font-size: 1.1em; text-align: center; width: auto;">

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CleanTime.live - Recovery Time Calculator</title>
+    <link rel="stylesheet" href="/stylesheets/style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>CleanTime.live</h1>
+
+        <div class="message">
+            <p><strong>What is CleanTime.live?</strong></p>
+            <p>CleanTime.live is a tool for recovery groups to collectively track and celebrate sobriety milestones. It allows groups to gather clean time data from their members and display combined totals during celebrations, anniversaries, and events.</p>
+        </div>
+
+        <div class="admin-section">
+            <h2 style="color: #667eea; margin-bottom: 15px;">How It Works</h2>
+            <ul style="list-style-position: inside; line-height: 2;">
+                <li>Each group gets their own private space</li>
+                <li>Members submit their clean date via a simple form</li>
+                <li>The tool calculates years, months, and days of sobriety</li>
+                <li>Groups can view combined totals for celebrations</li>
+                <li>QR codes available for easy mobile access</li>
+            </ul>
+        </div>
+
+        <hr>
+
+        <div class="admin-section">
+            <h2 style="color: #667eea; margin-bottom: 15px;">Request Access</h2>
+            <p style="margin-bottom: 15px;">CleanTime.live is not self-service. To request a space for your group, please submit an issue on GitHub:</p>
+            <a href="https://github.com/bmlt-enabled/diffcalc/issues/new?title=Request%20new%20group%20space&body=Group%20name:%0AContact%20email:%0A"
+               class="btn-edit"
+               style="display: inline-block; padding: 14px 30px; font-size: 1.1em; text-align: center; width: auto;">
+                Request a Space
+            </a>
+        </div>
+
+        <hr>
+
+        <div style="text-align: center; color: #777; font-size: 0.9em;">
+            <p>CleanTime.live is a free service for recovery communities.</p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a homepage at `/` explaining what CleanTime.live is
- Describes how the tool works for recovery groups
- Provides a GitHub issues link for requesting access (not self-service)
- Moves health check endpoint to `/health`

## Test plan
- [ ] Visit `/` and verify the homepage renders correctly
- [ ] Verify `/health` returns OK for Render health checks
- [ ] Click the "Request a Space" button to confirm it opens a GitHub issue template

Generated with [Claude Code](https://claude.com/claude-code)